### PR TITLE
Fix As_project.files_of_generators.

### DIFF
--- a/lib/as_project.ml
+++ b/lib/as_project.ml
@@ -1193,7 +1193,7 @@ let doc_public t = t.doc_public
 let files_of_generators t resolver =
   let comps = Component.(filter cu t.components) in
   List.fold_left (fun acc u ->
-      if CU.generated u then acc
+      if not (CU.generated u) then acc
       else
         let ml = match CU.ml u with
           | true  -> [CU.build_dir u resolver / CU.name u ^ ".ml"]


### PR DESCRIPTION
This would return the _non_ generated files and would
pile a list of useless rm's in distclean.

For example in assemblage's Makefile:

```
distclean:: clean
        rm -f Makefile assemblage.install META doc/*.html
        rm -rf $(BUILDIR)/lib-assemblage/as_flags.ml.ml
        rm -rf $(BUILDIR)/lib-assemblage/as_flags.mli.ml
        rm -rf $(BUILDIR)/lib-assemblage/as_resolver.ml.ml
        rm -rf $(BUILDIR)/lib-assemblage/as_resolver.mli.ml
        rm -rf $(BUILDIR)/lib-assemblage/as_features.ml.ml
        rm -rf $(BUILDIR)/lib-assemblage/as_features.mli.ml
        rm -rf $(BUILDIR)/lib-assemblage/as_shell.ml.ml
        rm -rf $(BUILDIR)/lib-assemblage/as_shell.mli.ml
        rm -rf $(BUILDIR)/lib-assemblage/as_action.ml.ml
        rm -rf $(BUILDIR)/lib-assemblage/as_action.mli.ml
        rm -rf $(BUILDIR)/lib-assemblage/as_git.ml.ml
        rm -rf $(BUILDIR)/lib-assemblage/as_git.mli.ml
        rm -rf $(BUILDIR)/lib-assemblage/as_project.ml.ml
        rm -rf $(BUILDIR)/lib-assemblage/as_project.mli.ml
        rm -rf $(BUILDIR)/lib-assemblage/as_ocamlfind.ml.ml
        rm -rf $(BUILDIR)/lib-assemblage/as_ocamlfind.mli.ml
        rm -rf $(BUILDIR)/lib-assemblage/as_OCaml.ml.ml
        rm -rf $(BUILDIR)/lib-assemblage/as_OCaml.mli.ml
        rm -rf $(BUILDIR)/lib-assemblage/as_build_env.ml.ml
        rm -rf $(BUILDIR)/lib-assemblage/as_build_env.mli.ml
        rm -rf $(BUILDIR)/lib-assemblage/as_makefile.ml.ml
        rm -rf $(BUILDIR)/lib-assemblage/as_makefile.mli.ml
        rm -rf $(BUILDIR)/lib-assemblage/as_opam.ml.ml
        rm -rf $(BUILDIR)/lib-assemblage/as_opam.mli.ml
```
