### PR TITLE
Makefile: provide a hook to add and extend targets externally.

### DIFF
--- a/Makefile.assemble
+++ b/Makefile.assemble
@@ -1,0 +1,6 @@
+# Included by Makefile
+
+distclean::
+	rm -f bin/configure.cmi
+	rm -f bin/configure.cmo
+	rm -f configure.boot

--- a/lib/as_makefile.ml
+++ b/lib/as_makefile.ml
@@ -228,6 +228,7 @@ let write t =
   Variable.generates buf t.variables;
   bprintf buf "\n";
   List.iter (Rule.generate buf) t.rules;
+  bprintf buf "-include Makefile.assemble\n\n";
   let oc = open_out t.makefile in
   output_string oc (Buffer.contents buf);
   close_out oc


### PR DESCRIPTION
Exemplified on assemblage itself.

That's just an idea, not necessarily to be merged.

Basically we just conditionally include a Makefile called `Makefile.assemble` at the end of the generated file. I used it on `assemblage` whose bootstrapping process leaves garbage in my repo that is not cleaned by a `distclean`. 
