### PR TITLE
Get rid of cu, wrap a few long lines and compactify As_project.

### DIFF
--- a/assemble.ml
+++ b/assemble.ml
@@ -18,15 +18,15 @@ let lib =
   lib "assemblage" (ocamldep ~dir:"lib" deps)
 
 let configure =
-  let configure = cu "configure" ~dir:"bin" [lib] in
+  let configure = unit "configure" ~dir:"bin" [lib] in
   bin "configure.ml" ~link_all:true ~byte_only:true [configure]
 
 let describe =
-  let describe = cu "describe" ~dir:"bin" [lib]  in
+  let describe = unit "describe" ~dir:"bin" [lib]  in
   bin "describe.ml" ~link_all:true ~byte_only:true [describe]
 
 let ctypes_gen =
-  let ctypes_gen = cu "ctypes_gen" ~dir:"bin" [lib] in
+  let ctypes_gen = unit "ctypes_gen" ~dir:"bin" [lib] in
   bin "ctypes-gen" ~byte_only:true [ctypes_gen]
 
 (* Tests *)

--- a/examples/camlp4/assemble.ml
+++ b/examples/camlp4/assemble.ml
@@ -1,13 +1,13 @@
 open Assemblage
 
-let t = cu "t" [
+let t = unit "t" [
     pkg_pp "sexplib.syntax";
     pkg_pp "comparelib.syntax";
     pkg    "sexplib";
     pkg    "comparelib";
     pkg    "xmlm";
   ]
-
+    
 let lib =
   lib "mylib" [t]
 

--- a/examples/cstubs/assemble.ml
+++ b/examples/cstubs/assemble.ml
@@ -3,7 +3,7 @@ open Assemblage
 let date = cstubs "date" []
 
 let date_cmd =
-  let date_cmd = cu "date_cmd" [date] in
+  let date_cmd = unit "date_cmd" [date] in
   bin "date-cmd" [date_cmd]
 
 let test =

--- a/examples/multi-libs/assemble.ml
+++ b/examples/multi-libs/assemble.ml
@@ -1,18 +1,18 @@
 open Assemblage
 
 let a =
-  lib "lib-a" [cu "a" ~dir:"a" [pkg "ezjsonm"]]
+  lib "lib-a" [unit "a" ~dir:"a" [pkg "ezjsonm"]]
 
 let a1 =
-  lib "lib-a-1" [cu "a1" ~dir:"a" [a]]
+  lib "lib-a-1" [unit "a1" ~dir:"a" [a]]
 
 let b =
-  let b = cu "b" ~dir:"b" [a] in
-  let c = cu "c" ~dir:"b" [b] in
+  let b = unit "b" ~dir:"b" [a] in
+  let c = unit "c" ~dir:"b" [b] in
   lib "lib2" [b; c]
 
 let bin =
-  bin "a-test" ~link_all:true ~deps:(fun _ -> [a; a1; b]) [cu "foo" []]
+  bin "a-test" ~link_all:true ~deps:(fun _ -> [a; a1; b]) [unit "foo" []]
 
 let () =
   create "multi-libs" [a; b; bin]

--- a/lib/as_OCaml.ml
+++ b/lib/as_OCaml.ml
@@ -126,23 +126,23 @@ let modules_of_mli ast =
 let modules ~build_dir cu =
   let resolver = As_ocamlfind.resolver `Direct build_dir in
   let () =
-    As_project.CU.deps cu
+    As_project.Unit.deps cu
     |> As_project.Component.closure
     |> As_project.Component.(filter pkg_pp)
     |> As_resolver.pkgs resolver
     |> init in
   let aux = function
     | `ML ->
-      let file = As_project.CU.(dir cu // name cu ^ ".ml") in
+      let file = As_project.Unit.(dir cu // name cu ^ ".ml") in
       let ast = Pparse.parse_implementation Format.err_formatter file in
       modules_of_ml ast
     | `MLI ->
-      let file = As_project.CU.(dir cu // name cu ^ ".mli") in
+      let file = As_project.Unit.(dir cu // name cu ^ ".mli") in
       let ast = Pparse.parse_interface Format.err_formatter file in
       modules_of_mli ast in
   let set =
-    if As_project.CU.mli cu then aux `MLI
-    else if As_project.CU.ml cu then aux `ML
+    if As_project.Unit.mli cu then aux `MLI
+    else if As_project.Unit.ml cu then aux `ML
     else StringSet.empty in
   StringSet.elements set
 
@@ -223,8 +223,8 @@ let depends ?flags ?(deps=fun _ -> []) resolver dir =
       let local_deps =
         try List.concat (Hashtbl.find_all deps_tbl name)
         with Not_found -> [] in
-      let deps = deps name @ List.map (fun x -> `CU (cu x)) local_deps in
-      let cu = As_project.CU.create ?flags ~dir ~deps name in
+      let deps = deps name @ List.map (fun x -> `Unit (cu x)) local_deps in
+      let cu = As_project.Unit.create ?flags ~dir ~deps name in
       Hashtbl.add cus_tbl name cu;
       cu in
   List.map cu names

--- a/lib/as_OCaml.mli
+++ b/lib/as_OCaml.mli
@@ -16,10 +16,10 @@
 
 (** Compiler-libs helpers. *)
 
-val modules: build_dir:string -> As_project.CU.t -> string list
+val modules: build_dir:string -> As_project.Unit.t -> string list
 (** Return the list of submodules defined in the given compilation unit. *)
 
 val depends: ?flags:As_flags.t -> ?deps:(string -> As_project.Component.t list) ->
-  As_resolver.t -> string -> As_project.CU.t list
+  As_resolver.t -> string -> As_project.Unit.t list
 (** [depends dir] computes the dependency graph of the compilation
     units in the directory [dir]. *)

--- a/lib/as_opam.ml
+++ b/lib/as_opam.ml
@@ -83,13 +83,13 @@ module Install = struct
       mk "index_values.html";
       mk "style.css";
       List.iter (fun l ->
-          let units = As_project.Lib.compilation_units l in
+          let units = As_project.Lib.units l in
           List.iter (fun u ->
-              let name = String.capitalize (As_project.CU.name u) in
+              let name = String.capitalize (As_project.Unit.name u) in
               mk "%s.html" name;
               mk "type_%s.html" name;
               let modules =
-                if As_project.CU.generated u then []
+                if As_project.Unit.generated u then []
                 else As_OCaml.modules ~build_dir u in
               List.iter (fun m ->
                   mk "%s.%s.html" name m

--- a/lib/as_project.mli
+++ b/lib/as_project.mli
@@ -139,7 +139,7 @@ module rec Component: sig
   (** Component descriptions. *)
 
   type t =
-    [ `CU of CU.t
+    [ `Unit of Unit.t
     | `Lib of Lib.t
     | `Pp of Lib.t
     | `Pkg_pp of Pkg.t
@@ -153,7 +153,7 @@ module rec Component: sig
 
   include S with type t := t and type component = t
 
-  val cu: t -> CU.t option
+  val unit: t -> Unit.t option
   (** Is the component a compilation unit? *)
 
   val lib: t -> Lib.t option
@@ -207,12 +207,12 @@ module rec Component: sig
   val pp_native: t list -> As_resolver.t -> string list
   (** Same as [pp_native] but for native pre-processors. *)
 
-  val link_byte: t list -> As_resolver.t -> CU.t list -> string list
+  val link_byte: t list -> As_resolver.t -> Unit.t list -> string list
   (** [link_byte deps r cus] is the list of command-line arguments to
       use for linking the compilation units [cus] together, depending
       on the components [ts] and using the name resolver [r]. *)
 
-  val link_native: t list -> As_resolver.t -> CU.t list -> string list
+  val link_native: t list -> As_resolver.t -> Unit.t list -> string list
 
   module Set: Set with type elt = t
   (** Set of components. *)
@@ -222,7 +222,7 @@ module rec Component: sig
 
 end
 
-and CU: sig
+and Unit : sig
 
   (** Signature for compilation units. *)
 
@@ -290,7 +290,7 @@ and Lib: sig
     ?pack:bool ->
     ?deps:(string -> Component.t list) ->
     ?c:C.t list ->
-    CU.t list -> string -> t
+    Unit.t list -> string -> t
   (** Create a library. *)
 
   val filename: t -> string
@@ -298,7 +298,7 @@ and Lib: sig
       this could be updated when the library is put in a named project
       to [project.name]. *)
 
-  val compilation_units: t -> CU.t list
+  val units: t -> Unit.t list
   (** The list of compilation units which defines the library. *)
 
   val c_objects: t -> C.t list
@@ -336,7 +336,7 @@ and Bin: sig
     ?install:bool ->
     ?flags:As_flags.t ->
     ?deps:(string -> Component.t list) ->
-    CU.t list -> string -> t
+    Unit.t list -> string -> t
   (** Build a binary by linking a set of compilation units. *)
 
   val toplevel:
@@ -345,11 +345,11 @@ and Bin: sig
     ?custom:bool ->
     ?install:bool ->
     ?deps:(string -> Component.t list) ->
-    CU.t list -> string -> t
+    Unit.t list -> string -> t
   (** Create a custom toplevel by linking a set of compilation
       units. *)
 
-  val compilation_units: t -> CU.t list
+  val units: t -> Unit.t list
   (** The list of compilation units contained in the binary. *)
 
   val available: t -> As_features.t

--- a/lib/assemblage.mli
+++ b/lib/assemblage.mli
@@ -172,7 +172,7 @@ end
 type t
 (** The type for OCaml projects descriptions. *)
 
-type cu
+type comp_unit
 (** The type for compilation unit descriptions. *)
 
 type lib
@@ -194,7 +194,7 @@ type gen
 (** The type for generated OCaml source code. *)
 
 type component =
-  [ `CU of cu
+  [ `Unit of comp_unit
   | `Lib of lib
   | `Pp of lib
   | `Pkg_pp of string
@@ -264,12 +264,14 @@ end
 
 (** {1 The Project API} *)
 
-val cu: ?dir:string -> string -> component list -> [> `CU of cu]
-(** [cu name ~dir deps] is the compilation unit located in the
+val unit: ?dir:string -> string -> component list -> 
+  [> `Unit of comp_unit]
+(** [unit name ~dir deps] is the compilation unit located in the
     directory [dir] with dependencies [deps] and the cname [name]. The
     name is the same as the filename, without its extension. *)
 
-val ocamldep: dir:string -> ?flags:Flags.t -> (string -> component list) -> [> `CU of cu] list
+val ocamldep: dir:string -> ?flags:Flags.t -> (string -> component list) -> 
+  [> `Unit of comp_unit] list
 (** [ocamldep ~dir deps] is the list of compilation units in the given
     directory, obtained by running [ocamldep] with the given flags and
     dependencies. [deps] is a map from compilation unit names to its
@@ -304,7 +306,7 @@ val lib:
   ?pack:bool ->
   ?deps:(string -> component list) ->
   ?c:[`C of c] list ->
-  string -> [`CU of cu] list -> [> `Lib of lib]
+  string -> [`Unit of comp_unit] list -> [> `Lib of lib]
 (** [lib name units] is the library [name] composed by the compilation
     units [cus]. If [lib] is set, use [ocamldep] to approximate the
     compilation units and their dependecies in the given directory. *)
@@ -314,7 +316,7 @@ val bin:
   ?link_all:bool ->
   ?install:bool ->
   ?deps:(string -> component list) ->
-  string -> [`CU of cu] list -> [> `Bin of bin]
+  string -> [`Unit of comp_unit] list -> [> `Bin of bin]
 (** [bin name units] is the binary [name] obtained by compiling
     the compilation units [units], with the dependencies [deps]. By
     default, the source files are located into {i bin/} (this is


### PR DESCRIPTION
`CU, CU, value cu and type cu type are replaced by`Unit, Unit, value unit and type comp_unit.

Sorry couldn't live with these one-line accessors that each took three lines to define, so I compacted the defs a bit in `As_project`. I work on lapots with limited vertical space and I don't see the point of scrolling that much. 
