### PR TITLE
As_component: when syntax error occurs, make sure to clean up output files

### DIFF
--- a/lib/as_component.ml
+++ b/lib/as_component.ml
@@ -584,11 +584,12 @@ module Unit = struct
                let target = file t r y in
                As_action.link r ~source ~target
            | Some preprocessor ->
-               As_action.create "%s %s %s > %s"
+             let out_file = file t r y in
+               As_action.create "%s %s %s > %s || ( rm -f %s && false )"
                  preprocessor
                  (String.concat " " (As_flags.get (`Pp mode) f))
                  (file t r x)
-                 (file t r y))
+                 out_file out_file)
     in
     let ocamldep x =
       let ocaml_files = match parent (`Unit t) with


### PR DESCRIPTION
Short-circuit `||` causes output to be removed after dumpast failure.
Subshell is necessary to guarantee removal process also returns an error
exit code. Fixes #110.