### PR TITLE
fix ocamlfind query for syntax,preprocessor preds

### DIFF
--- a/lib/as_ocamlfind.ml
+++ b/lib/as_ocamlfind.ml
@@ -72,11 +72,16 @@ let query ~mode = match mode with
   | `Makefile -> query_makefile
 
 let pp_byte ~mode names =
-  query ~mode
-    ~predicates:["syntax";"preprocessor"]
-    ~recursive:true
-    ~format:"%d/%a"
-    names
+  (query ~mode
+     ~predicates:["syntax";"preprocessor"]
+     ~recursive:true
+     ~format:"-I %d"
+     names
+  )@(query ~mode
+       ~predicates:["syntax";"preprocessor"]
+       ~recursive:true
+       ~format:"%a"
+       names)
 
 (*
 let pp_native ~mode names =


### PR DESCRIPTION
ocamlfind query with a combined directory and archive format gives wrong answers for syntax extensions which use packages that aren't syntax extensions (like cow). ocamlfind query will not correctly recursively descend and resolve the archive filenames and instead will append archive files for non-syntax packages to the directory of the present library. However, ocamlfind query will correctly return the directories where dependencies can be found and can return the archives listed as dependencies. Now, As_ocamlfind uses the directories as an include path and the archives as relative references. This works correctly if the package being used has all transitively dependent archives in the requires list in a partial order by dependency relation.
