### PR TITLE
First steps to make the Makefile backend bootstrap again.

### DIFF
--- a/.merlin
+++ b/.merlin
@@ -7,6 +7,7 @@ B _build/lib-assemblage
 B _build/bin-ctypes-gen
 B _build/bin-assemble
 B _build/bin-assemblage
+B _build/**
 
 S lib
 S lib-driver

--- a/assemble.ml
+++ b/assemble.ml
@@ -42,7 +42,6 @@ let lib_assemblage =
       unit "as_pkg_config";
       unit "as_part";
       unit "as_part_bin";
-      unit "as_part_custom";
       unit "as_part_dir";
       unit "as_part_doc";
       unit "as_part_lib";

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -5,7 +5,7 @@ set -ex
 OCAMLFIND=${OCAMLFIND:="ocamlfind"}
 
 BDIR="_build/bootstrap"
-PKGS="-package cmdliner"
+PKGS="-package cmdliner -package bytes"
 CMOS=""
 
 # Make sure $BDIR is clean

--- a/driver/builder_makefile.ml
+++ b/driver/builder_makefile.ml
@@ -29,11 +29,14 @@ let warn_no_actions = format_of_string
 type gen =
   { proj : Project.t;   (* The project to generate. *)
     dirs : Path.Set.t;  (* Set of directories that need to exist. *)
+    incs : Path.Set.t;  (* Set of Makefile fragments to include. *)
+    preps : Path.Set.t Path.Map.t; (* reverse deps for '.prepare' targets *)
     phony : string list;
     rmk : Makefile.t;   (* Reversed makefile definition. *) }
 
 let generator proj =
-  { proj; dirs = Path.Set.empty; phony = [];
+  { proj; dirs = Path.Set.empty; incs = Path.Set.empty; phony = [];
+    preps = Path.Map.empty;
     rmk =
       `Blank ::
       (`Comment "Run `make help` to get the list of targets.") ::
@@ -91,19 +94,44 @@ let mk_run_action name gen action = (* treated specially, phony *)
   let rmk = rule :: gen.rmk in
   { gen with phony; rmk; }
 
+let mk_dep_action gen inputs =
+  let add_include incs p =
+    if Path.has_ext `Ml_dep p || Path.has_ext `Mli_dep p
+    then Path.Set.add p incs else incs
+  in
+  let incs = List.fold_left add_include gen.incs inputs in
+  { gen with incs }
+
+let mk_prepare gen inputs p =
+  let seen =
+    try Path.Map.find p gen.preps
+    with Not_found -> Path.Set.empty
+  in
+  let seen = List.fold_left (fun set x -> Path.Set.add x set) seen inputs in
+  let preps = Path.Map.add p seen gen.preps in
+  { gen with preps }
+
 (* TODO check and warn about empty targets and cmds and skip *)
 let mk_action gen action =
   let inputs = Action.inputs action in
   let outputs = Action.outputs action in
-  let dirs = Path.(Set.elements (Set.of_list (List.rev_map dirname outputs))) in
-  let order_only_prereqs = List.rev_map Path.to_string dirs in
-  let prereqs = List.(rev (rev_map Path.to_string inputs)) in
-  let targets = List.(rev (rev_map Path.to_string outputs)) in
-  let recipe = mk_recipe gen action in
-  let rule = Makefile.rule ~order_only_prereqs ~targets ~prereqs ~recipe () in
-  let rmk = rule :: gen.rmk in
-  let dirs = List.fold_left (fun set d -> Path.Set.add d set) gen.dirs dirs in
-  { gen with dirs; rmk; }
+  let prepare, outputs = List.partition (Path.has_ext `Prepare) outputs in
+  if prepare = [] then (
+    let dirs = Path.(Set.elements (Set.of_list (List.rev_map dirname outputs))) in
+    let order_only_prereqs = List.rev_map Path.to_string dirs in
+    let prereqs = List.(rev (rev_map Path.to_string inputs)) in
+    let targets = List.(rev (rev_map Path.to_string outputs)) in
+    let recipe = mk_recipe gen action in
+    let rule = Makefile.rule ~order_only_prereqs ~targets ~prereqs ~recipe () in
+    let rmk = rule :: gen.rmk in
+    let dirs = List.fold_left (fun set d -> Path.Set.add d set) gen.dirs dirs in
+    let gen = mk_dep_action gen inputs in
+    { gen with dirs; rmk; }
+  ) else (
+    assert (List.length prepare = 1); (* FIXME: it should not happen,
+                                         but who knows ... *)
+    mk_prepare gen inputs (List.hd prepare)
+  )
 
 let mk_part gen p =
   if not (Project.eval gen.proj (Part.exists p)) then gen else
@@ -134,7 +162,7 @@ let mk_gen_dirs gen =
   let rmk = `Blank :: `Comment header :: `Blank :: gen.rmk in
   Path.Set.fold add_dir gen.dirs { gen with rmk }
 
-let mk_phony gen =
+let mk_gen_phony gen =
   let rule =
     let targets = [".PHONY"] in
     let prereqs = gen.phony in
@@ -142,10 +170,34 @@ let mk_phony gen =
   in
   { gen with rmk = rule :: `Blank :: gen.rmk }
 
+(* Generate the .d files *)
+let mk_gen_ds gen =
+  let add_include file gen =
+    let rmk = `Include (Path.to_string file) :: gen.rmk in
+    { gen with rmk }
+  in
+  Path.Set.fold add_include gen.incs gen
+
+(* Generate the .prepare files *)
+let mk_gen_prepare gen =
+  let add_prepare p inputs gen =
+    let prereqs = Path.Set.fold (fun x l -> Path.to_string x :: l) inputs [] in
+    let targets = [Path.to_string p] in
+    let recipe = [[Printf.sprintf "echo $(date) 1> %s" (Path.to_string p)]] in
+    let rule = Makefile.rule ~targets ~prereqs ~recipe () in
+    let rmk = rule :: gen.rmk in
+    { gen with rmk }
+  in
+  let header = "Prepare rules" in
+  let rmk = `Blank :: `Comment header :: `Blank :: gen.rmk in
+  Path.Map.fold add_prepare gen.preps { gen with rmk }
+
 let of_project ~setup_files proj =
   let gen = generator proj in
   let gen = keys gen in
   let gen = List.fold_left mk_part gen (Project.parts gen.proj) in
   let gen = mk_gen_dirs gen in
-  let gen = mk_phony gen in
+  let gen = mk_gen_ds gen in
+  let gen = mk_gen_phony gen in
+  let gen = mk_gen_prepare gen in
   List.rev gen.rmk

--- a/driver/makefile.ml
+++ b/driver/makefile.ml
@@ -55,7 +55,8 @@ let rule ?(ext = false) ?(order_only_prereqs = []) ~targets ~prereqs ~recipe
 
 type statement =
   [ `Var of var
-  | `Rule of rule ]
+  | `Rule of rule
+  | `Include of string ]
 
 type t = [ statement | `Comment of string | `Blank ] list
 
@@ -112,6 +113,12 @@ let buf_add_comment b c =
   Buffer.add_char b '\n';
   ()
 
+let buf_add_include b f =
+  Buffer.add_string b "-include "; (* FIXME: add an option for - ? *)
+  Buffer.add_string b f;
+  Buffer.add_char b '\n';
+  ()
+
 let to_string mk =
   let b = Buffer.create 8192 in
   let add = function
@@ -119,6 +126,7 @@ let to_string mk =
   | `Var v -> buf_add_var b v
   | `Rule r -> buf_add_rule b r
   | `Comment c -> buf_add_comment b c
+  | `Include f -> buf_add_include b f
   in
   List.iter add mk;
   Buffer.contents b

--- a/driver/makefile.mli
+++ b/driver/makefile.mli
@@ -79,7 +79,8 @@ val rule : ?ext:bool -> ?order_only_prereqs:string list ->
 
 type statement =
   [ `Var of var
-  | `Rule of rule ]
+  | `Rule of rule
+  | `Include of string ]
 (** The type for makefile statements. *)
 
 type t = [ statement | `Comment of string | `Blank ] list

--- a/lib/as_action_ocaml.mli
+++ b/lib/as_action_ocaml.mli
@@ -35,6 +35,23 @@ val compile_src_ast :
   [`Ml | `Mli] -> src:As_path.t -> unit ->
   As_action.t
 
+(** {1 Dependencies} *)
+
+val prepare:
+  stamp:(As_path.t -> string -> As_acmd.t) -> src:As_path.t -> As_action.t
+
+val compute_deps_mli:
+  ?needs:As_path.t list -> ?pkgs:pkgs -> ?args:string list ->
+  ocamldep:As_acmd.cmd ->
+  incs:includes -> src:As_path.t -> unit ->
+  As_action.t
+
+val compute_deps_ml:
+  ?needs:As_path.t list -> ?pkgs:pkgs -> ?args:string list ->
+  ocamldep:As_acmd.cmd ->
+  incs:includes -> src:As_path.t -> unit ->
+  As_action.t
+
 (** {1 Compiling} *)
 
 val compile_mli :

--- a/lib/as_cmd.ml
+++ b/lib/as_cmd.ml
@@ -122,7 +122,7 @@ module File = struct
   let read file =
     let input ic () =
       let len = in_channel_length ic in
-      let s = String.create len in
+      let s = Bytes.create len in
       really_input ic s 0 len; ret s
     in
     with_inf input file ()

--- a/lib/as_path.ml
+++ b/lib/as_path.ml
@@ -158,7 +158,7 @@ type ext =
   | `Cmxs | `Css | `Dll | `Exe | `Gif | `H | `Html | `Install | `Img
   | `Jpeg | `Js | `Json | `Lib | `Md | `Ml | `Ml_dep | `Ml_pp | `Mli
   | `Mli_dep | `Mli_pp | `Native | `O | `Opt | `Png | `Sh | `So | `Tar
-  | `Tbz | `Xml | `Zip
+  | `Tbz | `Xml | `Zip | `Prepare
   | `Ext of string ]
 
 let ext_to_string = function
@@ -172,7 +172,7 @@ let ext_to_string = function
 | `Mli_dep -> "mli-dep" | `Mli_pp -> "mli-pp" | `Native -> "native"
 | `O -> "o" | `Opt -> "opt" | `Png -> "png" | `Sh -> "sh" | `So -> "so"
 | `Tar -> "tar" | `Tbz -> "tbz" | `Xml -> "xml" | `Zip -> "zip"
-| `Ext ext -> ext
+| `Prepare -> "prepare" | `Ext ext -> ext
 
 let ext_of_string = function
 | "a" -> `A | "byte" -> `Byte | "c" -> `C | "cma" -> `Cma | "cmi" -> `Cmi
@@ -185,7 +185,7 @@ let ext_of_string = function
 | "mli-dep" -> `Mli_dep | "mli-pp" -> `Mli_pp | "native" -> `Native
 | "o" -> `O | "opt" -> `Opt | "png" -> `Png | "sh" -> `Sh | "so" -> `So
 | "tar" -> `Tar | "tbz"  -> `Tbz | "xml" -> `Xml | "zip" -> `Zip
-| ext -> `Ext ext
+| "prepare" -> `Prepare | ext -> `Ext ext
 
 let pp_ext ppf e = As_fmt.pp_str ppf (ext_to_string e)
 

--- a/lib/as_path.mli
+++ b/lib/as_path.mli
@@ -70,7 +70,7 @@ type ext =
   | `Cmxs | `Css | `Dll | `Exe | `Gif | `H | `Html | `Install | `Img
   | `Jpeg | `Js | `Json | `Lib | `Md | `Ml | `Ml_dep | `Ml_pp | `Mli
   | `Mli_dep | `Mli_pp | `Native | `O | `Opt | `Png | `Sh | `So | `Tar
-  | `Tbz | `Xml | `Zip
+  | `Tbz | `Xml | `Zip | `Prepare
   | `Ext of string ]
 
 val ext_to_string : ext -> string

--- a/lib/assemblage.mli
+++ b/lib/assemblage.mli
@@ -360,7 +360,7 @@ module Path : sig
     | `Cmxs | `Css | `Dll | `Exe | `Gif | `H | `Html | `Install | `Img
     | `Jpeg | `Js | `Json | `Lib | `Md | `Ml | `Ml_dep | `Ml_pp | `Mli
     | `Mli_dep | `Mli_pp | `Native | `O | `Opt | `Png | `Sh | `So | `Tar
-    | `Tbz | `Xml | `Zip
+    | `Tbz | `Xml | `Zip | `Prepare
     | `Ext of string ]
   (** The type for file extensions. *)
 


### PR DESCRIPTION
Support for dynamic inter-module dependency discovering. A bit
hackish, but not too much actually. With that patch, the library
bootstrap again, yay!

The current scheme to turn our pretty applicative DSL into a monadic monstruosity:
- add a `<dir>.prepare` step, which goal is to symlink all the source
  files into the build dir <dir>. This need some kind of convolutions
  and is done partly in the backend, as Assemblage has only access to
  the reverse information in the project description. But the current
  solution is not too bad and generic enough (I think).
- to compile a ml or mli your first need to build the corresponding
  ml-deps or mli-dep (very similar to ocamlbuild, ocp-build and
  other).
- to generate a ml-deps or mli-deps you must first prepare all the
  include directories (ie. <dir>.prepare). This ensure that ocamldep
  has all the relevant information to compute correct dynamic
  dependencies.
- And finally, the final trick is to `-include` all the ml-deps and
  mli-deps to lazily add the new depenencies infered by ocamldep.

This is all (relatively) standard in the Makefile world and it seems
to work fine on my relatively limited testing.
