### PR TITLE
As_cmd.write[_subst]: create tempfile in the same dir as the target file.

### DIFF
--- a/lib/as_cmd.mli
+++ b/lib/as_cmd.mli
@@ -54,7 +54,7 @@ module File : sig
   val dev_null : As_path.t
   val exists : As_path.t -> bool result
   val delete : ?maybe:bool -> As_path.t -> unit result
-  val temp : string -> As_path.t result
+  val temp : ?dir:As_path.t -> string -> As_path.t result
   val with_inf : (in_channel -> 'a -> 'b result) -> As_path.t -> 'a -> 'b result
   val read : As_path.t -> string result
   val read_lines : As_path.t -> string list result

--- a/lib/assemblage.mli
+++ b/lib/assemblage.mli
@@ -801,9 +801,11 @@ module Cmd : sig
     (** [delete ~maybe file] deletes file [file]. If [maybe] is [false]
         (default) no error is returned if the file doesn't exit. *)
 
-    val temp : string -> path result
-    (** [temp suffix] creates a temporary file with suffix [suffix] and returns
-        its name. The file is destroyed at the end of program execution. *)
+    val temp : ?dir:path -> string -> path result
+    (** [temp dir suffix] creates a temporary file with suffix
+        [suffix] in [dir] (defaults to {!Filename.get_temp_dir_name})
+        and returns its name. The file is destroyed at the end of
+        program execution. *)
 
     (** {1:input Input} *)
 


### PR DESCRIPTION
Fixes #154.