### PR TITLE
Enhance Cmd.{File,Dir,Path}.exists and Cmd.exists.

### DIFF
--- a/lib/as_cmd.mli
+++ b/lib/as_cmd.mli
@@ -46,13 +46,13 @@ end
 type path = As_path.t (* to avoid assemblage.mli confusion *)
 
 module Path : sig
-  val exists : As_path.t -> bool result
+  val exists : ?err:bool -> As_path.t -> bool result
   val move : ?force:bool -> As_path.t -> As_path.t -> unit result
 end
 
 module File : sig
   val dev_null : As_path.t
-  val exists : As_path.t -> bool result
+  val exists : ?err:bool -> As_path.t -> bool result
   val delete : ?maybe:bool -> As_path.t -> unit result
   val temp : ?dir:As_path.t -> string -> As_path.t result
   val with_inf : (in_channel -> 'a -> 'b result) -> As_path.t -> 'a -> 'b result
@@ -67,7 +67,7 @@ module File : sig
 end
 
 module Dir : sig
-  val exists : As_path.t -> bool result
+  val exists : ?err:bool -> As_path.t -> bool result
   val getcwd : unit -> As_path.t result
   val chdir : As_path.t -> unit result
   val fold_files_rec : ?skip:string list -> (string -> 'a -> 'a result) ->
@@ -96,7 +96,7 @@ val get_env : string -> string result
 
 (** {1 Executing commands} *)
 
-val exists : string -> bool result
+val exists : ?err:bool -> string -> bool result
 val exec_ret : string -> string list -> int
 val exec : string -> string list -> unit result
 val read : ?trim:bool -> string -> string list -> string result

--- a/lib/assemblage.mli
+++ b/lib/assemblage.mli
@@ -772,8 +772,10 @@ module Cmd : sig
 
     (** {1:pathops Path operations} *)
 
-    val exists : path -> bool result
-    (** [exists path] is [true] iff [path] exists. *)
+    val exists : ?err:bool -> path -> bool result
+    (** [exists err path] is [true] iff [path] exists.
+        If [err] is [true] (defaults to [false]) an error is returned
+        when the file doesn't exist. *)
 
     val move : ?force:bool -> path -> path -> unit result
     (** [move ~force src dst] moves path [src] to [dst]. If [force] is
@@ -788,8 +790,10 @@ module Cmd : sig
         {b Note.} When paths are {{!Path.rel}relative} they are expressed
         relative to the {{!Dir.getcwd}current working directory}. *)
 
-    val exists : path -> bool result
-    (** [exists file] is [true] iff [file] exists and is not a directory. *)
+    val exists : ?err:bool -> path -> bool result
+    (** [exists err file] is [true] iff [file] exists and is not a directory.
+        If [err] is [true] (defaults to [false]) an error is returned
+        when the file doesn't exist. *)
 
     val dev_null : path
     (** [dev_null] represents a file that discards all writes.
@@ -865,8 +869,10 @@ module Cmd : sig
         {b Note.} When paths are {{!Path.rel}relative} they are expressed
         relative to the {{!Dir.getcwd}current working directory}. *)
 
-    val exists : path -> bool result
-    (** [exists dir] is [true] if directory [dir] exists. *)
+    val exists : ?err:bool -> path -> bool result
+    (** [exists err dir] is [true] if directory [dir] exists.
+        If [err] is [true] (defaults to [false]) an error is returned
+        when the file doesn't exist. *)
 
     val getcwd : unit -> path result
     (** [getcwd ()] is the current working directory. *)
@@ -929,8 +935,10 @@ module Cmd : sig
 
   (** {1:executing_commands Executing commands} *)
 
-  val exists : string -> bool result
-  (** [exists cmd] is [true] if [cmd] exists and can be invoked. *)
+  val exists : ?err:bool -> string -> bool result
+  (** [exists err cmd] is [true] if [cmd] exists and can be invoked.
+      If [err] is [true] (defaults to [false]) an error is returned
+      when the command doesn't exist. *)
 
   val exec_ret : string -> string list -> int
   (** [exec_ret cmd args] executes [cmd] with arguments [args] and


### PR DESCRIPTION
Add an ?err optional argument to turn nonexistence in errors.

Fixes #150.